### PR TITLE
Authorization base64 encoding is not functioning properly

### DIFF
--- a/lib/arango.js
+++ b/lib/arango.js
@@ -24,7 +24,6 @@ var BROWSER = (typeof window ==='object' && window.hasOwnProperty('location')),
 include.query = require('./query');
 include.action = require('./action');
 include.request = require('./request');
-include.cryptojs = require('./ext/crypto');
 
 include.api = {
   "collection": require('./api/collection'),
@@ -73,7 +72,6 @@ function Connection() {
 
 }
 
-    Connection.prototype.crypto = include.cryptojs;
 
     Connection.prototype.use = function() {
         for(var i = 0, connection; connection = arguments[i]; i++) {
@@ -107,8 +105,8 @@ function Connection() {
         this.name = this.name || "";
 
         /* Basic authorization */
-        if(this.username) this.auth = 'Basic ' + 
-            this.crypto.enc.Utf8.parse(this.username + ':' + this.password).toString(this.crypto.enc.Base64);
+        if(this.username) this.auth = 'Basic ' +
+		     new Buffer(this.username + ':' + this.password, 'utf-8').toString('base64');
 
         return this;
     }

--- a/lib/arango.js
+++ b/lib/arango.js
@@ -106,7 +106,7 @@ function Connection() {
 
         /* Basic authorization */
         if(this.username) this.auth = 'Basic ' +
-		     new Buffer(this.username + ':' + this.password, 'utf-8').toString('base64');
+            new Buffer(this.username + ':' + this.password, 'utf-8').toString('base64');
 
         return this;
     }


### PR DESCRIPTION
The crypto module used to create base64 encoding for authorization header is not working.  When arangodb is protected with password all the APIs are failing producing no results.  I've changed the implementation using standard Buffer class.
